### PR TITLE
Remove trailing zeroes from output

### DIFF
--- a/.idea/.idea.BinaryPack/.idea/.gitignore
+++ b/.idea/.idea.BinaryPack/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/projectSettingsUpdater.xml
+/modules.xml
+/contentModel.xml
+/.idea.BinaryPack.iml

--- a/.idea/.idea.BinaryPack/.idea/.name
+++ b/.idea/.idea.BinaryPack/.idea/.name
@@ -1,0 +1,1 @@
+BinaryPack

--- a/src/BinaryPack/BinaryConverter.cs
+++ b/src/BinaryPack/BinaryConverter.cs
@@ -27,7 +27,7 @@ namespace BinaryPack
             {
                 ObjectProcessor<T>.Instance.Serializer(obj, ref writer);
 
-                return writer.Buffer;
+                return writer.Span.ToArray();
             }
             finally
             {
@@ -49,7 +49,7 @@ namespace BinaryPack
             {
                 ObjectProcessor<T>.Instance.Serializer(obj, ref writer);
 
-                stream.Write(writer.Buffer, 0, writer.Buffer.Length);
+                stream.Write(writer.Span.ToArray(), 0, writer.Span.Length);
             }
             finally
             {

--- a/src/BinaryPack/Serialization/Buffers/BinaryWriter.cs
+++ b/src/BinaryPack/Serialization/Buffers/BinaryWriter.cs
@@ -45,12 +45,6 @@ namespace BinaryPack.Serialization.Buffers
         }
 
         /// <summary>
-        /// Returns the buffer used by the writer to avoid copying. The writer should not be written to or disposed while
-        /// the buffer is being used externally.
-        /// </summary>
-        public byte[] Buffer => _Buffer;
-
-        /// <summary>
         /// Writes a value of type <typeparamref name="T"/> to the underlying buffer
         /// </summary>
         /// <typeparam name="T">The type of value to write to the buffer</typeparam>

--- a/unit/BinaryPack.Models/BinaryPack.Models.projitems
+++ b/unit/BinaryPack.Models/BinaryPack.Models.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AbstractPacketModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DynamicSizeModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HelloWorldModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\LinQExtension.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\MathFExtension.cs" />

--- a/unit/BinaryPack.Models/DynamicSizeModel.cs
+++ b/unit/BinaryPack.Models/DynamicSizeModel.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq;
+
+#nullable enable
+
+namespace BinaryPack.Models
+{
+    /// <summary>
+    /// A simple model that contains data of dynamic size
+    /// </summary>
+    [Serializable]
+    public sealed class DynamicSizeModel : IEquatable<DynamicSizeModel>
+    {
+        public int[] IntValues { get; set; }
+        public bool[] BoolValues { get; set; }
+
+        public void Initialize(int size)
+        {
+            int sizeInts = size / 4;
+            int sizeBooleans = size % 4;
+
+            IntValues = new int[sizeInts];
+            BoolValues = new bool[sizeBooleans];
+
+            Random rnd = new Random();
+            for (int i = 0; i < sizeInts; i++)
+            {
+                IntValues[i] = rnd.Next();
+            }
+            for (int i = 0; i < sizeBooleans; i++)
+            {
+                BoolValues[i] = rnd.NextDouble() >= 0.5;
+            }
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(DynamicSizeModel? other)
+        {
+            if (other is null) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return IntValues.SequenceEqual(other.IntValues) && BoolValues.SequenceEqual(other.BoolValues);
+        }
+    }
+}

--- a/unit/BinaryPack.Unit.Internals/SizeTest.cs
+++ b/unit/BinaryPack.Unit.Internals/SizeTest.cs
@@ -8,7 +8,11 @@ namespace BinaryPack.Unit.Internals
     public class SizeTest
     {
         // Test method for ensuring size of deserialized objects
-        private static void Test(int size)
+        [TestMethod]
+        [DataRow(0)]
+        [DataRow(1024)]
+        [DataRow(9999)]
+        public void SizeSerializationTest(int size)
         {
             // Initialize
             DynamicSizeModel model = new DynamicSizeModel();
@@ -25,14 +29,5 @@ namespace BinaryPack.Unit.Internals
             Assert.IsTrue(model.Equals(result));
             Assert.AreEqual(size, stream.Length - 9); //9 bytes are serialization overhead
         }
-
-        [TestMethod]
-        public void ZeroDataSerializationTest() => Test(0);
-
-        [TestMethod]
-        public void Size1024SerializationTest() => Test(1024);
-
-        [TestMethod]
-        public void Size9999SerializationTest() => Test(9999);
     }
 }

--- a/unit/BinaryPack.Unit.Internals/SizeTest.cs
+++ b/unit/BinaryPack.Unit.Internals/SizeTest.cs
@@ -1,0 +1,38 @@
+﻿using System.IO;
+using BinaryPack.Models;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BinaryPack.Unit.Internals
+{
+    [TestClass]
+    public class SizeTest
+    {
+        // Test method for ensuring size of deserialized objects
+        private static void Test(int size)
+        {
+            // Initialize
+            DynamicSizeModel model = new DynamicSizeModel();
+            model.Initialize(size);
+
+            // Serialize
+            using MemoryStream stream = new MemoryStream();
+            BinaryConverter.Serialize(model, stream);
+
+            // Deserialize
+            stream.Seek(0, SeekOrigin.Begin);
+            DynamicSizeModel result = BinaryConverter.Deserialize<DynamicSizeModel>(stream);
+
+            Assert.IsTrue(model.Equals(result));
+            Assert.AreEqual(size, stream.Length - 9); //9 bytes are serialization overhead
+        }
+
+        [TestMethod]
+        public void ZeroDataSerializationTest() => Test(0);
+
+        [TestMethod]
+        public void Size1024SerializationTest() => Test(1024);
+
+        [TestMethod]
+        public void Size9999SerializationTest() => Test(9999);
+    }
+}


### PR DESCRIPTION
A failed optimization attempt lead to BinaryConverter returning the buffer it was writing to directly. This buffer is always 1024 bytes by default, so the output array will always be 1024 bytes even if the serialized data uses a lot less data than that. By reverting this change, the output will not contain hundreds of trailing zeroes anymore.