### PR TITLE
Fix unhelpful generated method names in stack traces

### DIFF
--- a/src/BinaryPack/BinaryPack.csproj
+++ b/src/BinaryPack/BinaryPack.csproj
@@ -1,19 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
+    <TargetFramework>net472</TargetFramework>
     <Nullable>enable</Nullable>
 	<LangVersion>latest</LangVersion>
     <PackageId>Nitrox.BinaryPack</PackageId>
     <Description>A fork of the official BinaryPack for use by the Nitrox project. It has a few additional features and provides support for net472.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Condition="'$(TargetFramework.TrimEnd(`0123456789`))' != 'net'" Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/src/BinaryPack/BinaryPack.csproj
+++ b/src/BinaryPack/BinaryPack.csproj
@@ -1,17 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
 	<LangVersion>latest</LangVersion>
     <PackageId>Nitrox.BinaryPack</PackageId>
     <Description>A fork of the official BinaryPack for use by the Nitrox project. It has a few additional features and provides support for net472.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" />
+    <PackageReference Condition="'$(TargetFramework.TrimEnd(`0123456789`))' != 'net'" Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/src/BinaryPack/Extensions/System.Reflection.Emit/DynamicMethod{T}.cs
+++ b/src/BinaryPack/Extensions/System.Reflection.Emit/DynamicMethod{T}.cs
@@ -55,7 +55,7 @@ namespace System.Reflection.Emit
         /// Creates a new unique id for a dynamic method
         /// </summary>
         [Pure]
-        private static string GetNewId() => $"__IL__{typeof(T).Name}_{Interlocked.Increment(ref _Count)}";
+        private static string GetNewId() => $"__IL__{typeof(T).Name}_{typeof(T).GetGenericArguments()[0].Name}_{Interlocked.Increment(ref _Count)}";
 
         /// <summary>
         /// Creates a new <see cref="DynamicMethod{T}"/> instance with an empty method

--- a/src/BinaryPack/Serialization/Processors/StringProcessor.cs
+++ b/src/BinaryPack/Serialization/Processors/StringProcessor.cs
@@ -135,7 +135,7 @@ namespace BinaryPack.Serialization.Processors
             il.Emit(OpCodes.Newobj, KnownMembers.Span.ArrayWithOffsetAndLengthConstructor(typeof(byte)));
             il.EmitCall(KnownMembers.BinaryReader.ReadSpanT(typeof(byte)));
 
-            // string text = Encoding.UTF8.GetString(p, length);
+            // string text = Encoding.UTF8.GetString(array, 0, length);
             il.EmitReadMember(typeof(Encoding).GetProperty(nameof(Encoding.UTF8)));
             il.EmitLoadLocal(Locals.Read.ByteArray);
             il.EmitLoadInt32(0);


### PR DESCRIPTION
Previously the emitted method would not include the type being de/serialized, making it very annoying to debug if given only a stack trace.